### PR TITLE
[1.20.1] Added MobTypes to some entities for compat

### DIFF
--- a/src/main/java/com/github/eterdelta/crittersandcompanions/entity/DragonflyEntity.java
+++ b/src/main/java/com/github/eterdelta/crittersandcompanions/entity/DragonflyEntity.java
@@ -71,6 +71,10 @@ public class DragonflyEntity extends TamableAnimal implements GeoEntity {
         this.entityData.define(ARMOR_ITEM, ItemStack.EMPTY);
     }
 
+    public MobType getMobType() {
+        return MobType.ARTHROPOD;
+    }
+
     @Override
     protected void registerGoals() {
         this.goalSelector.addGoal(0, new SitWhenOrderedToGoal(this));
@@ -139,7 +143,7 @@ public class DragonflyEntity extends TamableAnimal implements GeoEntity {
         flyingPathNavigation.setCanFloat(true);
         return flyingPathNavigation;
     }
-
+    
     @Override
     public boolean causeFallDamage(float p_147187_, float p_147188_, DamageSource p_147189_) {
         return false;

--- a/src/main/java/com/github/eterdelta/crittersandcompanions/entity/DumboOctopusEntity.java
+++ b/src/main/java/com/github/eterdelta/crittersandcompanions/entity/DumboOctopusEntity.java
@@ -90,6 +90,10 @@ public class DumboOctopusEntity extends WaterAnimal implements GeoEntity, Bucket
         this.entityData.define(FROM_BUCKET, false);
     }
 
+    public MobType getMobType() {
+        return MobType.WATER;
+    }
+
     @Override
     protected void registerGoals() {
         this.goalSelector.addGoal(0, new BubblePlayerGoal());

--- a/src/main/java/com/github/eterdelta/crittersandcompanions/entity/JumpingSpiderEntity.java
+++ b/src/main/java/com/github/eterdelta/crittersandcompanions/entity/JumpingSpiderEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.MobType;
 import net.minecraft.world.entity.TamableAnimal;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -50,6 +51,10 @@ public class JumpingSpiderEntity extends TamableAnimal implements GeoEntity {
 
     public static AttributeSupplier.Builder createAttributes() {
         return Spider.createAttributes().add(Attributes.MAX_HEALTH, 14.0D).add(Attributes.ATTACK_DAMAGE, 8.0D);
+    }
+
+    public MobType getMobType() {
+        return MobType.ARTHROPOD;
     }
 
     @Override

--- a/src/main/java/com/github/eterdelta/crittersandcompanions/entity/KoiFishEntity.java
+++ b/src/main/java/com/github/eterdelta/crittersandcompanions/entity/KoiFishEntity.java
@@ -45,6 +45,10 @@ public class KoiFishEntity extends AbstractSchoolingFish implements GeoEntity {
         this.entityData.define(VARIANT, 0);
     }
 
+    public MobType getMobType() {
+        return MobType.WATER;
+    }
+
     @Override
     protected void registerGoals() {
         super.registerGoals();

--- a/src/main/java/com/github/eterdelta/crittersandcompanions/entity/LeafInsectEntity.java
+++ b/src/main/java/com/github/eterdelta/crittersandcompanions/entity/LeafInsectEntity.java
@@ -56,6 +56,10 @@ public class LeafInsectEntity extends PathfinderMob implements GeoEntity {
         this.entityData.define(VARIANT, 0);
     }
 
+    public MobType getMobType() {
+        return MobType.ARTHROPOD;
+    }
+
     @Override
     protected void registerGoals() {
         this.goalSelector.addGoal(0, new WaterAvoidingRandomStrollGoal(this, 1.0D));

--- a/src/main/java/com/github/eterdelta/crittersandcompanions/entity/SeaBunnyEntity.java
+++ b/src/main/java/com/github/eterdelta/crittersandcompanions/entity/SeaBunnyEntity.java
@@ -19,6 +19,7 @@ import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.MobType;
 import net.minecraft.world.entity.SpawnGroupData;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -83,6 +84,10 @@ public class SeaBunnyEntity extends WaterAnimal implements Bucketable, GeoEntity
         this.entityData.define(CLIMBING, false);
         this.entityData.define(VARIANT, 0);
         this.entityData.define(FROM_BUCKET, false);
+    }
+
+    public MobType getMobType() {
+        return MobType.WATER;
     }
 
     @Override


### PR DESCRIPTION
Some creatures, particularly the arthropods, didn't have their MobType set as such.  Some mods use MobTypes in their code, such as if an entity hunts Arthropods, so this is to add a little more compat to them.  Tested it myself, works great.

Changes: 
- The Dragonfly, Jumping Spider, and Leaf Insect are set to `MobType.ARTHROPOD`
- The Dumbo Octopus, Koi Fish, and Sea Bunny are set to `MobType.WATER`

Let me know if there's any way I can help.  Thanks for such an awesome mod!