### PR TITLE
Fix: Prevent crash by adding null check to GrapplingHookEntity

### DIFF
--- a/common/src/main/java/com/github/eterdelta/crittersandcompanions/entity/GrapplingHookEntity.java
+++ b/common/src/main/java/com/github/eterdelta/crittersandcompanions/entity/GrapplingHookEntity.java
@@ -47,11 +47,13 @@ public class GrapplingHookEntity extends ThrowableItemProjectile {
             addedToWorld = true;
         }
 
-        if (getOwner() == null) {
+        var owner = getOwner();
+        if (owner == null) {
             discard();
             return;
         }
-        var offsetLengthSqr = distanceToSqr(getOwner());
+
+        var offsetLengthSqr = distanceToSqr(owner);
 
         var maxDistance = Services.CONFIGS.common().grapplingHookMaxDistance.get();
         var maxDistanceSqr = maxDistance * maxDistance;
@@ -77,14 +79,14 @@ public class GrapplingHookEntity extends ThrowableItemProjectile {
         }
 
         isStick = willStick;
-        if (isStick && getOwner() != null) {
+        if (isStick) {
             if (offsetLengthSqr > stickLength) {
-                var direction = position().subtract(getOwner().position()).normalize();
+                var direction = position().subtract(owner.position()).normalize();
                 var maxSpeed = Services.CONFIGS.common().grapplingHookMaxSpeed.get();
                 var scale = Math.min(maxSpeed, 0.01D * Math.sqrt(offsetLengthSqr));
                 if (scale >= 0) {
-                    getOwner().setDeltaMovement(getOwner().getDeltaMovement().add(direction.scale(scale)));
-                    getOwner().hurtMarked = true;
+                    owner.setDeltaMovement(owner.getDeltaMovement().add(direction.scale(scale)));
+                    owner.hurtMarked = true;
                 }
             }
             setDeltaMovement(0.0D, 0.0D, 0.0D);

--- a/common/src/main/java/com/github/eterdelta/crittersandcompanions/entity/GrapplingHookEntity.java
+++ b/common/src/main/java/com/github/eterdelta/crittersandcompanions/entity/GrapplingHookEntity.java
@@ -47,6 +47,10 @@ public class GrapplingHookEntity extends ThrowableItemProjectile {
             addedToWorld = true;
         }
 
+        if (getOwner() == null) {
+            discard();
+            return;
+        }
         var offsetLengthSqr = distanceToSqr(getOwner());
 
         var maxDistance = Services.CONFIGS.common().grapplingHookMaxDistance.get();


### PR DESCRIPTION
Added a null check before doing calculations in the ticks() for the grappling hook. Effectively removing recent reported crashes where the owner disconnected or the hook went through a portal.